### PR TITLE
Expand TagRules from 11 to 50

### DIFF
--- a/assets/data-sets/circulation_view.json
+++ b/assets/data-sets/circulation_view.json
@@ -262,6 +262,240 @@
                 "ColumnName": "libary_short_name",
                 "TagMultiValueDelimiter": "|",
                 "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_11",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_12",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_13",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_14",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_15",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_16",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_17",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_18",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_19",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_20",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_21",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_22",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_23",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_24",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_25",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_26",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_27",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_28",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_29",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_30",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_31",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_32",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_33",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_34",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_35",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_36",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_37",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_38",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_39",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_40",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_41",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_42",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_43",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_44",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_45",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_46",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_47",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_48",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_49",
+                "ColumnName": "libary_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
             }
         ],
         "TagRuleConfigurations": [
@@ -276,7 +510,46 @@
                 "library_short_name_7",
                 "library_short_name_8",
                 "library_short_name_9",
-                "library_short_name_10"
+                "library_short_name_10",
+                "library_short_name_11",
+                "library_short_name_12",
+                "library_short_name_13",
+                "library_short_name_14",
+                "library_short_name_15",
+                "library_short_name_16",
+                "library_short_name_17",
+                "library_short_name_18",
+                "library_short_name_19",
+                "library_short_name_20",
+                "library_short_name_21",
+                "library_short_name_22",
+                "library_short_name_23",
+                "library_short_name_24",
+                "library_short_name_25",
+                "library_short_name_26",
+                "library_short_name_27",
+                "library_short_name_28",
+                "library_short_name_29",
+                "library_short_name_30",
+                "library_short_name_31",
+                "library_short_name_32",
+                "library_short_name_33",
+                "library_short_name_34",
+                "library_short_name_35",
+                "library_short_name_36",
+                "library_short_name_37",
+                "library_short_name_38",
+                "library_short_name_39",
+                "library_short_name_40",
+                "library_short_name_41",
+                "library_short_name_42",
+                "library_short_name_43",
+                "library_short_name_44",
+                "library_short_name_45",
+                "library_short_name_46",
+                "library_short_name_47",
+                "library_short_name_48",
+                "library_short_name_49"
             ]
         ]
     },

--- a/assets/data-sets/patron_events.json
+++ b/assets/data-sets/patron_events.json
@@ -172,6 +172,240 @@
                 "ColumnName": "library_short_name",
                 "TagMultiValueDelimiter": "|",
                 "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_11",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_12",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_13",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_14",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_15",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_16",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_17",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_18",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_19",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_20",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_21",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_22",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_23",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_24",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_25",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_26",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_27",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_28",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_29",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_30",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_31",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_32",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_33",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_34",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_35",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_36",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_37",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_38",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_39",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_40",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_41",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_42",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_43",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_44",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_45",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_46",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_47",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_48",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
+            },
+            {
+                "TagKey": "library_short_name_49",
+                "ColumnName": "library_short_name",
+                "TagMultiValueDelimiter": "|",
+                "MatchAllValue": "*"
             }
         ],
         "TagRuleConfigurations": [
@@ -186,7 +420,46 @@
                 "library_short_name_7",
                 "library_short_name_8",
                 "library_short_name_9",
-                "library_short_name_10"
+                "library_short_name_10",
+                "library_short_name_11",
+                "library_short_name_12",
+                "library_short_name_13",
+                "library_short_name_14",
+                "library_short_name_15",
+                "library_short_name_16",
+                "library_short_name_17",
+                "library_short_name_18",
+                "library_short_name_19",
+                "library_short_name_20",
+                "library_short_name_21",
+                "library_short_name_22",
+                "library_short_name_23",
+                "library_short_name_24",
+                "library_short_name_25",
+                "library_short_name_26",
+                "library_short_name_27",
+                "library_short_name_28",
+                "library_short_name_29",
+                "library_short_name_30",
+                "library_short_name_31",
+                "library_short_name_32",
+                "library_short_name_33",
+                "library_short_name_34",
+                "library_short_name_35",
+                "library_short_name_36",
+                "library_short_name_37",
+                "library_short_name_38",
+                "library_short_name_39",
+                "library_short_name_40",
+                "library_short_name_41",
+                "library_short_name_42",
+                "library_short_name_43",
+                "library_short_name_44",
+                "library_short_name_45",
+                "library_short_name_46",
+                "library_short_name_47",
+                "library_short_name_48",
+                "library_short_name_49"
             ]
         ]
     },


### PR DESCRIPTION
## Summary

- Expands `TagRules` and `TagRuleConfigurations` from 11 entries (indices 0–10) to 50 entries (indices 0–49) in both `circulation_view.json` and `patron_events.json`
- Follows the same pattern established in c672001 (PP-3504), which expanded from 7 to 11 to support anonymous users seeing all libraries on CMs with large numbers of libraries

## Context
https://ebce-lyrasis.atlassian.net/browse/PP-4369 

## Test plan

- [x] Verify JSON is valid: `python3 -m json.tool assets/data-sets/circulation_view.json` and `patron_events.json`
- [x] Confirm 50 `TagKey` entries exist in each file
- [ ] Deploy datasets to a QuickSight environment and confirm anonymous users can access CM QS dashboard for Illiniois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)